### PR TITLE
Moved batcache config to fix error message output

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -96,7 +96,13 @@
      * in their development environments.
      */
     define('WP_DEBUG', false);
-
+    
+    // configures batcache
+    $batcache = [
+      'seconds'=>0,
+      'max_age'=>30*60, // 30 minutes
+      'debug'=>false
+    ];
     /* That's all, stop editing! Happy blogging. */
 
     /** Absolute path to the WordPress directory. */
@@ -106,9 +112,4 @@
     /** Sets up WordPress vars and included files. */
     require_once(ABSPATH . 'wp-settings.php');
 
-   // configures batcache
-    $batcache = [
-      'seconds'=>0,
-      'max_age'=>30*60, // 30 minutes
-      'debug'=>false
-    ];
+


### PR DESCRIPTION
Moving config location fixes the "call_user_func_array() expects parameter 1 to be a valid callback" warning from being displayed in the header.

With the cache working I went from a 1000ms response to 30ms.
