### PR TITLE
Disable the virtual cron and set the real cron job from cron.yaml to run every 15 minutes.

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,4 +1,4 @@
 cron:
 - description: wordpress cron tasks
   url: /wp-cron.php
-  schedule: every 2 hours
+  schedule: every 15 minutes

--- a/wp-config.php
+++ b/wp-config.php
@@ -97,6 +97,11 @@
      */
     define('WP_DEBUG', false);
     
+    /**
+     * Disable default wp-cron in favor of a real cron job
+     */
+    define('DISABLE_WP_CRON', true);
+    
     // configures batcache
     $batcache = [
       'seconds'=>0,


### PR DESCRIPTION
By default wp-cron.php is run every single page load, since setting up real cron jobs seems to be too complicated for a default wordpress users ;). While most times wp-cron should only be a check that there is no jobs waiting for run, it slows down things. And in the case that we have a site nicely in batcache, the first cache miss will often spawn the cron slowing down the non-cached page load even more, up to one or two seconds. Since we can easily use a real cron job (and have already used one), let's disable the virtual one.

The interval of the cron job is slightly arguable, but I prefer 15 minutes so e.g. scheduled posts will be published about in time, not two hours late.